### PR TITLE
fix(prop-types): Removing some unecessary propTypes

### DIFF
--- a/src/__tests__/pane.spec.js
+++ b/src/__tests__/pane.spec.js
@@ -47,16 +47,35 @@ describe('Pane', () => {
       expect(wastedButton.prop('testID')).toEqual('btn-wasted');
     });
 
-    it('should have a inclusive button display', () => {
+    it('should have an inclusive button display', () => {
       expect(inclusiveButton.prop('testID')).toEqual('btn-inclusive');
     });
 
-    it('should have a exclusive button display', () => {
+    it('should have an exclusive button display', () => {
       expect(exclusiveButton.prop('testID')).toEqual('btn-exclusive');
     });
 
-    it('should have a opeartions button display', () => {
+    it('should have an operations button display', () => {
       expect(operationsButton.prop('testID')).toEqual('btn-operations');
+    });
+
+    it('shouldnt have an exlusive button if printExlusive isnt provided by the monitor', () => {
+      monitorSpy = {
+        printWasted: jest.fn(),
+        printInclusive: jest.fn(),
+        printOperations: jest.fn(),
+      };
+      wrapper = shallow(<Pane onClose={spyOnClose} monitor={monitorSpy} />);
+      expect(wrapper.find({ testID: 'btn-exclusive' }).length).toEqual(0);
+    });
+
+    it('shouldnt have an operations button if printOperations isnt provided by the monitor', () => {
+      monitorSpy = {
+        printWasted: jest.fn(),
+        printInclusive: jest.fn(),
+      };
+      wrapper = shallow(<Pane onClose={spyOnClose} monitor={monitorSpy} />);
+      expect(wrapper.find({ testID: 'btn-operations' }).length).toEqual(0);
     });
   });
 

--- a/src/pane.js
+++ b/src/pane.js
@@ -7,22 +7,22 @@ import PaneItem from './paneItem';
 export default class Pane extends PureComponent {
   printWasted = () => {
     this.props.monitor.printWasted();
-  }
+  };
 
   printInclusive = () => {
     this.props.monitor.printInclusive();
-  }
+  };
 
   printExclusive = () => {
     this.props.monitor.printExclusive();
-  }
+  };
 
   printOps = () => {
     this.props.monitor.printOperations();
-  }
+  };
 
   render() {
-    const { onClose } = this.props;
+    const { onClose, monitor } = this.props;
     return (
       <Modal transparent onRequestClose={onClose} animationType="slide">
         <View style={Style.container}>
@@ -40,17 +40,21 @@ export default class Pane extends PureComponent {
                 content="Print inclusive"
                 bordered
               />
-              <PaneItem
-                testID="btn-exclusive"
-                onPress={this.printExclusive}
-                content="Print exclusive"
-                bordered
-              />
-              <PaneItem
-                testID="btn-operations"
-                onPress={this.printOps}
-                content="Print Operations"
-              />
+              {monitor.printExclusive && (
+                <PaneItem
+                  testID="btn-exclusive"
+                  onPress={this.printExclusive}
+                  content="Print exclusive"
+                  bordered
+                />
+              )}
+              {monitor.printOperations && (
+                <PaneItem
+                  testID="btn-operations"
+                  onPress={this.printOps}
+                  content="Print Operations"
+                />
+              )}
             </View>
             <View style={Style.pane}>
               <PaneItem testID="pane-close" onPress={onClose} content="Close" />
@@ -67,7 +71,7 @@ Pane.propTypes = {
   monitor: PropTypes.shape({
     printWasted: PropTypes.func.isRequired,
     printInclusive: PropTypes.func.isRequired,
-    printExclusive: PropTypes.func.isRequired,
-    printOperations: PropTypes.func.isRequired,
+    printExclusive: PropTypes.func,
+    printOperations: PropTypes.func,
   }).isRequired,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.31", "@babel/code-frame@^7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz#473d021ecc573a2cce1c07d5b509d5215f46ba35"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz#afe63ad799209989348b1109b44feb66aa245f57"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.31"
+    "@babel/template" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/helper-get-function-arity@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz#1176d79252741218e0aec872ada07efb2b37a493"
+  dependencies:
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/template@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.31", "@babel/traverse@^7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.31.tgz#db399499ad74aefda014f0c10321ab255134b1df"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/helper-function-name" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.31", "@babel/types@^7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.31.tgz#42c9c86784f674c173fb21882ca9643334029de4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@types/node@^6.0.46":
   version "6.0.90"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.90.tgz#0ed74833fa1b73dcdb9409dcb1c97ec0a8b13b02"
@@ -300,6 +353,15 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.7.2:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.2.tgz#e44fb9a037d749486071d52d65312f5c20aa7530"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.31"
+    "@babel/traverse" "^7.0.0-beta.31"
+    "@babel/types" "^7.0.0-beta.31"
+    babylon "^7.0.0-beta.31"
 
 babel-generator@^6.18.0, babel-generator@^6.24.1, babel-generator@^6.26.0:
   version "6.26.0"
@@ -873,6 +935,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.31, babylon@^7.0.0-beta.31:
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -2233,6 +2299,10 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^10.0.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.3.0.tgz#716aba93657b56630b5a0e77de5ea8ac6215afaa"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2501,7 +2571,7 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3305,7 +3375,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4984,6 +5054,10 @@ tmpl@1.0.x:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"


### PR DESCRIPTION
Removing `printOperations` and `printExclusive` from mandatory props for `monitor`.

They seem to have been removed in some of the used packages like : 

https://github.com/facebook/react/blob/94f44aeba72eacb04443974c2c6c91a050d61b1c/packages/react-native-renderer/src/ReactNativeRenderer.js#L121